### PR TITLE
Renamed LibKlustersShared to Neurosuite

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,14 +49,14 @@ endif()
 
 
 include(MacroEnsureVersion)
-find_package(LibKlustersShared 2.0.0 REQUIRED)
+find_package(Neurosuite 2.0.0 REQUIRED)
 include(CheckCXXCompilerFlag)
 add_definitions(${QT_DEFINITIONS})
 set( QT_USE_XML TRUE)
 set( QT_USE_QTWEBKIT TRUE)
 
 # tell cmake where to search for Qt/KDE headers:
-include_directories(${QT_INCLUDE_DIR} ${CMAKE_CURRENT_BINARY_DIR} ${QT_QTXML_INCLUDE_DIR} ${LIBKLUSTERSSHARED_INCLUDE_DIR} )
+include_directories(${QT_INCLUDE_DIR} ${CMAKE_CURRENT_BINARY_DIR} ${QT_QTXML_INCLUDE_DIR} ${NEUROSUITE_INCLUDE_DIR} )
 
 if(QT_QTWEBKIT_FOUND)
 	include_directories(${QT_QTWEBKIT_INCLUDE_DIR})


### PR DESCRIPTION
As far as I can see, LibKlustersShared was renamed to Neurosuite
This fixes the error caused by renaming of the library.